### PR TITLE
Restart services only if they are monitored by monit

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -5,6 +5,7 @@ function get_running_services() {
   for s in "$@"; do
     monitored=$(wget -q -O - localhost:2812/_status?format=xml | xmlstarlet sel -t -v "/monit/service[name='${s}']/monitor")
     if [[ "$monitored" == "1" ]]; then
+      # Order of services is retained when returning
       running_svcs=(${running_svcs[@]} "$s")
     fi
   done

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function get_running_services() {
-  running_svcs=()  
+  local running_svcs=()  
   for s in "$@"; do
     monitored=$(wget -q -O - localhost:2812/_status?format=xml | xmlstarlet sel -t -v "/monit/service[name='${s}']/monitor")
     if [[ "$monitored" == "1" ]]; then

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function get_running_services() {
+  running_svcs=()  
+  for s in "$@"; do
+    monitored=$(wget -q -O - localhost:2812/_status?format=xml | xmlstarlet sel -t -v "/monit/service[name='$s']/monitor")
+    if [[ "$monitored" == "0" ]]; then
+      running_svcs=(${running_svcs[@]} "$s")
+    fi
+  done
+
+  echo "${running_svcs[@]}"
+}

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -3,8 +3,8 @@
 function get_running_services() {
   running_svcs=()  
   for s in "$@"; do
-    monitored=$(wget -q -O - localhost:2812/_status?format=xml | xmlstarlet sel -t -v "/monit/service[name='$s']/monitor")
-    if [[ "$monitored" == "0" ]]; then
+    monitored=$(wget -q -O - localhost:2812/_status?format=xml | xmlstarlet sel -t -v "/monit/service[name='${s}']/monitor")
+    if [[ "$monitored" == "1" ]]; then
       running_svcs=(${running_svcs[@]} "$s")
     fi
   done

--- a/hadoop/util.sh
+++ b/hadoop/util.sh
@@ -7,8 +7,8 @@ export HADOOP_ETC_DIR=${HADOOP_ETC_DIR:-/usr/lib/hadoop2/etc/hadoop}
 declare -A SVC_USERS=([namenode]=hdfs [timelineserver]=yarn [historyserver]=mapred [resourcemanager]=yarn [datanode]=hdfs)
 
 function start_daemon() {
-  daemon=shift;
-  case "SVC_USERS[$daemon]" in
+  daemon=$1;
+  case "${SVC_USERS[$daemon]}" in
     yarn)
       /bin/su -s /bin/bash -c "/usr/lib/hadoop2/sbin/yarn-daemon.sh start $daemon" yarn
       ;;
@@ -25,7 +25,7 @@ function start_daemon() {
 }
 
 function stop_daemon() {
-  daemon=shift;
+  daemon=$1;
   case "${SVC_USERS[$daemon]}" in
     yarn)
       /bin/su -s /bin/bash -c "/usr/lib/hadoop2/sbin/yarn-daemon.sh stop $daemon" yarn
@@ -43,8 +43,8 @@ function stop_daemon() {
 }
 
 function restart_services() {
-  svcs="$@"
-  running_svcs=find_running_services "${svcs[@]}"
+  svcs=("$@")
+  running_svcs=($(find_running_services "${svcs[@]}"))
   for s in "${running_svcs[@]}"; do
     monit unmonitor "$s"
   done

--- a/hadoop/util.sh
+++ b/hadoop/util.sh
@@ -44,7 +44,7 @@ function stop_daemon() {
 
 function restart_services() {
   svcs=("$@")
-  running_svcs=($(find_running_services "${svcs[@]}"))
+  running_svcs=($(get_running_services "${svcs[@]}"))
   for s in "${running_svcs[@]}"; do
     monit unmonitor "$s"
   done
@@ -55,10 +55,13 @@ function restart_services() {
 
   last=${#running_svcs[@]}
 
+  # Restart services in reverse order of how
+  # they were stopped
   for (( i=0; i <last; i++ )); do
     start_daemon "${running_svcs[~i]}"
   done
 
+  # Order doesn't matter for (un)monitor
   for s in "${running_svcs[@]}"; do
     monit monitor "$s"
   done


### PR DESCRIPTION
This helps avoid cluster-specific checks. e.g. Spark History Server should only be restarted on spark clusters. Instead of checking - in the bootstrap function - if we're running on a spark cluster, the service will be restarted only if it is monitored by monit.  

In future this will be extended to handle systemd/upstart.