### PR TITLE
updating glue-sync.sh , putting delay of 30 sec before hs2 startup

### DIFF
--- a/hive/glue-sync.sh
+++ b/hive/glue-sync.sh
@@ -39,8 +39,10 @@ function install_glue_sync() {
         export OVERRIDE_HADOOP_JAVA_HOME=/usr/lib/jvm/java-1.8.0
         /usr/lib/hive1.2/bin/thrift-metastore server stop && sleep 5 && /usr/lib/hive1.2/bin/thrift-metastore server start
         monit monitor metastore1_2
-
+       
         if is_hs2_configured; then
+            sleep 30
+            rm -f /tmp/jdbc.log
             /usr/lib/hive1.2/bin/hiveserver2-admin stop && sleep 5 && /bin/bash /usr/lib/hive1.2/usr-bin/startHS2.sh
         fi
         rm -f /tmp/jdbc.log


### PR DESCRIPTION
updating glue-sync.sh , putting delay of 30 sec before hs2 startup because metastore and hs2 startup for gluecatalog using same log jdbc.log causing issue on hs2 startup
@nitinik @hiyer 