### PR TITLE
Configure prometheus ram on master node

### DIFF
--- a/prometheus/configure-prometheus-ram.sh
+++ b/prometheus/configure-prometheus-ram.sh
@@ -1,22 +1,20 @@
 #!/usr/bin/env bash
 #
 # @file prometheus/configure-prometheus-ram.sh
-# @brief Provides functions to Configure Prometheus memory usage on master node
-
-
-# @description Ability to specify the memory usage of prometheus daemon on master. Example : 500M
+# @brief Provides functions to configure Prometheus
+#
+#
+# @description Ability to override the memory usage of prometheus daemon on master. Example : 500M
+#
+#  function requires one argument to be passed.
+#  Argument must specify the ram to be allocated to the prometheus service from master node ram.
+#  Input should be an integer. All the values are assumed in MB.
 #
 # @example
-#      function requires one argument to be passed.
-#      Argument must specify the ram to be allocated to the prometheus service from master node ram.
-#      Input should be an integer. All the values are assumed in MB.
+#      configure_prometheus_ram_on_master 600
 #
-#      Example of function calling :-
-#      1) configure_prometheus_ram_on_master '600'
-#      2) configure_prometheus_ram_on_master 600
-#      Both of them are acceptable.
+# @arg $1 integer Prometheus ram to be substituted in MB.
 #
-#      sed -i "s/PROMETHEUS_RAM/$1/g" /usr/lib/prometheus/config/docker-compose.yml
 #
 
 function configure_prometheus_ram_on_master() {
@@ -36,5 +34,3 @@ function configure_prometheus_ram_on_master() {
   fi
 
 }
-
-

--- a/prometheus/configure-prometheus-ram.sh
+++ b/prometheus/configure-prometheus-ram.sh
@@ -23,7 +23,12 @@
 #
 #
 function configure_prometheus_ram_on_master() {
-  sed -i "s/PROMETHEUS_RAM/$1/g" /usr/lib/prometheus/config/docker-compose.yml
+  prometheus_ram=$1
+  regex_number='^[0-9]+$'
+  prometheus_ram_with_suffix="${prometheus_ram}M"
+  if [[ -n $prometheus_ram ]] && [[ $prometheus_ram =~ $regex_number ]]; then
+    sed -i "s/PROMETHEUS_RAM/$prometheus_ram_with_suffix/g" /usr/lib/prometheus/config/docker-compose.yml
+  fi
 }
 
 

--- a/prometheus/configure-prometheus-ram.sh
+++ b/prometheus/configure-prometheus-ram.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# @file prometheus/configure-prometheus-ram.sh
+# @brief Provides functions to Configure Prometheus memory usage on master node
+
+
+# @description Ability to specify the memory usage of prometheus daemon on master. Example : 500M
+#
+# @example
+#      function requires one argument to be passed.
+#      Argument must specify the ram to be allocated to the prometheus service from master node ram.
+#
+#      Suffixes :-
+#      1) Add 'M' at the end to denote Megabyte.
+#      2) Add 'G' at the end to denote Gigabyte
+#
+#      Example of function calling :-
+#      1) configure_prometheus_ram_on_master '600M'
+#      2) configure_prometheus_ram_on_master 600M
+#      Both of them are acceptable.
+#
+#      sed -i "s/PROMETHEUS_RAM/$1/g" /usr/lib/prometheus/config/docker-compose.yml
+#
+#
+function configure_prometheus_ram_on_master() {
+  sed -i "s/PROMETHEUS_RAM/$1/g" /usr/lib/prometheus/config/docker-compose.yml
+}
+
+

--- a/prometheus/configure-prometheus-ram.sh
+++ b/prometheus/configure-prometheus-ram.sh
@@ -9,26 +9,32 @@
 # @example
 #      function requires one argument to be passed.
 #      Argument must specify the ram to be allocated to the prometheus service from master node ram.
-#
-#      Suffixes :-
-#      1) Add 'M' at the end to denote Megabyte.
-#      2) Add 'G' at the end to denote Gigabyte
+#      Input should be an integer. All the values are assumed in MB.
 #
 #      Example of function calling :-
-#      1) configure_prometheus_ram_on_master '600M'
-#      2) configure_prometheus_ram_on_master 600M
+#      1) configure_prometheus_ram_on_master '600'
+#      2) configure_prometheus_ram_on_master 600
 #      Both of them are acceptable.
 #
 #      sed -i "s/PROMETHEUS_RAM/$1/g" /usr/lib/prometheus/config/docker-compose.yml
 #
-#
+
 function configure_prometheus_ram_on_master() {
+
   prometheus_ram=$1
+  # Regex to determine whether the input is a number or not.
   regex_number='^[0-9]+$'
+
+  # Add suffix 'M' to the user's input.
   prometheus_ram_with_suffix="${prometheus_ram}M"
+
   if [[ -n $prometheus_ram ]] && [[ $prometheus_ram =~ $regex_number ]]; then
+
+    # If the user input is non-empty and is matching with the given regex, then we can override the value.
     sed -i "s/PROMETHEUS_RAM/$prometheus_ram_with_suffix/g" /usr/lib/prometheus/config/docker-compose.yml
+
   fi
+
 }
 
 

--- a/prometheus/configure-prometheus.sh
+++ b/prometheus/configure-prometheus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# @file prometheus/configure-prometheus-ram.sh
+# @file prometheus/configure-prometheus.sh
 # @brief Provides functions to configure Prometheus
 #
 #


### PR DESCRIPTION
 @description Ability to specify the memory usage of Prometheus daemon on the master. Example: 500M

1)  function requires one argument to be passed.
2)  The argument must specify the ram to be allocated to the Prometheus service from the master node ram.


Example of a function call:-
    configure_prometheus_ram_on_master 600

